### PR TITLE
Change version in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "mathematica-notebook-filter"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
Hello.
After I had execute `cargo build` from the your latest version,
The following modification occurs.
I think version bump e631645211e0c8668b880ac29971a47a13a25f23 can also be done in `Cargo.lock` in this case.